### PR TITLE
Expose packages as an overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,9 +9,8 @@
 { pkgs ? import <nixpkgs> { } }:
 
 let
-  athena-pkgs = import ./pkgs { inherit pkgs; };
-  athena-python = with athena-pkgs; [ python-discuss python-afs python-hesiod locker-support ];
-  athena-python3 = (pkgs.python3.withPackages (ps: (map (pkg: pkg ps) athena-python)));
+  athena-pkgs = pkgs.extend (import ./pkgs);
+  athena-python3 = athena-pkgs.python3.withPackages (ps: with ps; [ python-discuss python-afs python-hesiod locker-support ]);
 in
 {
   # The `lib`, `modules`, and `overlays` names are special
@@ -23,19 +22,20 @@ in
     additions = final: prev: {athena-pkgs=builtins.trace "evaluating the overlay" athena-pkgs;};
   };
 
-  inherit athena-pkgs;
+  inherit athena-pkgs athena-python3;
   # linkFarmFromDrvs is undocumented, but the source is at
   # https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/trivial-builders/default.nix#L578
   default = pkgs.linkFarmFromDrvs "nixathena-pkgs" (with athena-pkgs; [ discuss pyhesiodfs remctl moira athena-python3 ]);
-  debathena-aclocal = athena-pkgs.debathena-aclocal;
-  discuss = athena-pkgs.discuss;
-  python-discuss = athena-pkgs.python-discuss;
-  python-afs = athena-pkgs.python-afs;
-  python-hesiod = athena-pkgs.python-hesiod;
-  pyhesiodfs = athena-pkgs.pyhesiodfs;
-  remctl = athena-pkgs.remctl;
-  moira = athena-pkgs.moira;
-  # some-qt5-package = pkgs.libsForQt5.callPackage ./pkgs/some-qt5-package { };
-  # ...
-  athena-python3 = athena-python3;
+  inherit (athena-pkgs)
+    debathena-aclocal
+    discuss
+    pyhesiodfs
+    remctl
+    moira
+  ;
+  inherit (athena-pkgs.python3Packages)
+    python-discuss
+    python-afs
+    python-hesiod
+  ;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,9 @@
           meta-standard = test-infra.metaStandardTest.driver;
         };
       });
+
+      overlays.default = import ./pkgs;
+
       packages = forAllSystems (system: nixpkgs.lib.filterAttrs (_: v: nixpkgs.lib.isDerivation v) self.legacyPackages.${system});
 
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,22 +1,26 @@
 # https://nix.dev/tutorials/packaging-existing-software#building-with-nix-build
 # default.nix
-{ pkgs }:
+final: prev:
 let
-in rec
+  inherit (final) callPackage;
+in
 {
-  debathena-aclocal = pkgs.callPackage ./aclocal.nix { };
-  discuss = pkgs.callPackage ./discuss.nix { inherit debathena-aclocal; };
-  python-discuss = ps: ps.callPackage ./python-discuss.nix { };
-  python-afs = ps: ps.callPackage ./python-afs.nix { };
-  hesiod = pkgs.callPackage ./hesiod.nix { };
-  python-hesiod = ps: ps.callPackage ./python-hesiod.nix { inherit hesiod; };
-  locker-support = ps: ps.callPackage ./locker-support.nix {
-    python-afs = (python-afs ps);
-    python-hesiod = (python-hesiod ps);
-  };
-  pyhesiodfs = pkgs.callPackage ./pyhesiodfs.nix { inherit python-hesiod locker-support; };
-  remctl = pkgs.callPackage ./remctl.nix { };
-  moira = pkgs.callPackage ./moira.nix { inherit hesiod; };
+  debathena-aclocal = callPackage ./aclocal.nix { };
+  discuss = callPackage ./discuss.nix { };
+  hesiod = callPackage ./hesiod.nix { };
+  pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+    (python-final: python-prev: let
+      inherit (python-final) callPackage;
+    in {
+      python-discuss = callPackage ./python-discuss.nix { };
+      python-afs = callPackage ./python-afs.nix { };
+      python-hesiod = callPackage ./python-hesiod.nix { };
+      locker-support = callPackage ./locker-support.nix { };
+    })
+  ];
+  pyhesiodfs = callPackage ./pyhesiodfs.nix { };
+  remctl = callPackage ./remctl.nix { };
+  moira = callPackage ./moira.nix { };
   # https://ryantm.github.io/nixpkgs/builders/images/dockertools/
 #   docker = pkgs.dockerTools.buildLayeredImage {
 #     name = "${dockerName}";

--- a/pkgs/locker-support.nix
+++ b/pkgs/locker-support.nix
@@ -1,6 +1,11 @@
-{ stdenv, pkgs, lib, fetchFromGitHub,
-  python3Packages, buildPythonPackage, setuptools,
-  python-afs, python-hesiod,
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  python-afs,
+  python-hesiod,
 }:
 
 # TODO: Also install binaries

--- a/pkgs/pyhesiodfs.nix
+++ b/pkgs/pyhesiodfs.nix
@@ -1,11 +1,11 @@
-{ stdenv, pkgs, lib, fetchFromGitHub,   # general nix
-  python3Packages,                      # nix python
-  python-hesiod, locker-support,        # athena
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  python3Packages,
 }:
 
-let
-  fs = lib.fileset;
-in python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "pyhesiodfs";
   version = "1.1";
 
@@ -22,9 +22,8 @@ in python3Packages.buildPythonApplication {
 
   dependencies = with python3Packages; [
     fuse
-    (python-hesiod python3Packages)
-    (locker-support python3Packages)
-    #(builtins.trace python-hesiod python-hesiod)
+    python-hesiod
+    locker-support
   ];
 
   #meta = with lib; {


### PR DESCRIPTION
This allows users to bring the packages into their existing package set, incorporating whatever versions of packages they already have pinned. (As opposed to referencing them via `packages.${system}.foo`, which yields a package pinned to the version of nixpkgs that the flake was instantiated with.) Also, because all the packages now use `callPackage` correctly, users can use `override` to replace any of the dependencies as per a normal package.

There were already a couple other things called `overlay` that I didn't touch - `overlay.nix` appears to be a non-flake entrypoint to get packages, `default.nix` contains a broken `overlays.additions` attribute, and `overlays/default.nix` appears to be empty and unreferenced. I wanted to keep the diff minimal but if you'd like me to clean those up as well I'd be happy to.

There's probably more cleanup that could be done in the structure, but I wasn't sure how much you wanted to stick to the NUR template. I also didn't touch the modules at all, so they still pull in packages with `import ../pkgs` instead of using an overlay.